### PR TITLE
Added gulp-notify for growl style notifications on JS linting errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "merge-stream": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.7",
     "run-sequence": "^1.0.2",
-    "yargs": "^4.7.1"
+    "yargs": "^4.7.1",
+    "gulp-notify": "^2.2.0"
   },
   "dependencies": {
     "angular": "^1.5.5",


### PR DESCRIPTION
Tested on OSX with node v5.11.1 only, because who has time to test?
